### PR TITLE
[Bug] Support non-jpeg for classification, add augmentation.

### DIFF
--- a/official/vision/beta/configs/image_classification.py
+++ b/official/vision/beta/configs/image_classification.py
@@ -40,6 +40,9 @@ class DataConfig(cfg.DataConfig):
   aug_rand_hflip: bool = True
   aug_type: Optional[
       common.Augmentation] = None  # Choose from AutoAugment and RandAugment.
+  aug_scale_min: float = 1.0
+  aug_scale_max: float = 1.0
+  preserve_aspect_ratio: bool = True
   file_type: str = 'tfrecord'
   image_field_key: str = 'image/encoded'
   label_field_key: str = 'image/class/label'

--- a/official/vision/beta/dataloaders/segmentation_input.py
+++ b/official/vision/beta/dataloaders/segmentation_input.py
@@ -98,6 +98,7 @@ class Parser(parser.Parser):
         data augmentation during training.
       aug_scale_max: `float`, the maximum scale applied to `output_size` for
         data augmentation during training.
+      preserve_aspect_ratio: `bool`, whether to preserve aspect ratio during resize
       rotate_min: `float`, the minimum rotation applied to `output_size` for
         data augmentation during training.
       rotate_max: `float`, the maximum rotation applied to `output_size` for


### PR DESCRIPTION
## Description
What feature/issue was addressed?
png images are not supported in current classification input.

How was it resolved/added?
Added support for it..

Add a Screenshot if there are changes to the UI

## Issue reference

Please reference the issue this PR will close: #13.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc

# Checklist
- [ ] I have not cleaned up my code. Forgive the minor errors
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [ ] I have commented my code, particularly in hard-to-understand areas
