### PR TITLE
[Feature] Add multihead serving definition.

### DIFF
--- a/official/vision/beta/ops/colormaps.py
+++ b/official/vision/beta/ops/colormaps.py
@@ -41,7 +41,29 @@ def get_colormap(cmap_type='cityscapes',
     empty_labels = tf.tile(tf.constant([[255]], dtype=tf.uint8), 
                            multiples=(ignore_label-max_label, 3))
     cmap = tf.concat((cmap, empty_labels), axis=0)
-
+  
+  elif cmap_type == 'cityscapes_int':
+    # two complement of above values + BGR instead of RGB
+    cmap = tf.constant([
+      -25149312, 
+      -18340876, 
+      -28948922, 
+      -23304602, 
+      -23488066, 
+      -23488103, 
+      -31544582, 
+      -33497892, 
+      -31224213, 
+      -23528552, 
+      -21724672, 
+      -29616932, 
+      -33554177, 
+      -24248320, 
+      -28966912, 
+      -26985472, 
+      -26980352, 
+      -18481152, 
+      -31454345], dtype=tf.int32)
   else:
     raise ValueError('Invalid colormap type specified %s.' %cmap_type)
 

--- a/official/vision/beta/scripts/export_saved_model.sh
+++ b/official/vision/beta/scripts/export_saved_model.sh
@@ -9,13 +9,6 @@ python ../serving/export_saved_model.py \
     --batch_size=1 \
     --input_image_size=256,256 \
     --config_file="../configs/experiments/${TASK_TYPE}/${CONFIG_FILENAME}.yaml" \
-    --input_type="image_tensor"
-
-python ../serving/export_saved_model.py \
-    --experiment="${EXPERIMENT}" \
-    --export_dir="${MODEL_DIR}/export_withargmax" \
-    --checkpoint_path="${MODEL_DIR}" \
-    --batch_size=1 \
-    --input_image_size=256,256 \
-    --config_file="../configs/experiments/${TASK_TYPE}/${CONFIG_FILENAME}.yaml" \
-    --input_type="image_tensor_with_argmax"
+    --input_type="image_tensor" \
+    --argmax_outputs \
+    --visualise_outputs

--- a/official/vision/beta/scripts/export_tflite_model.sh
+++ b/official/vision/beta/scripts/export_tflite_model.sh
@@ -4,8 +4,5 @@ set +o posix
 exec > >(tee ${MODEL_DIR}/export_tflite_output.log) 2>&1
 python ../serving/export_tflite_model.py \
     --saved_model_dir="${MODEL_DIR}/export/saved_model" \
-    --export_path="${MODEL_DIR}/export/model.tflite"
-
-python ../serving/export_tflite_model.py \
-    --saved_model_dir="${MODEL_DIR}/export_withargmax/saved_model" \
-    --export_path="${MODEL_DIR}/export_withargmax/model.tflite"
+    --export_path="${MODEL_DIR}/export/model.tflite" \
+    --optimise='float16'

--- a/official/vision/beta/serving/export_base.py
+++ b/official/vision/beta/serving/export_base.py
@@ -102,13 +102,6 @@ class ExportModule(export_base.ExportModule, metaclass=abc.ABCMeta):
   def inference_from_image_tensors(
       self, inputs: tf.Tensor) -> Mapping[str, tf.Tensor]:
     return self.serve(inputs)
-  
-  @tf.function
-  def inference_from_image_tensors_with_argmax(
-      self, inputs: tf.Tensor) -> Mapping[str, tf.Tensor]:
-    masks = self.serve(inputs)['predicted_masks']
-    masks = tf.math.argmax(masks, -1)
-    return dict(predicted_masks=masks)
 
   @tf.function
   def inference_from_image_bytes(self, inputs: tf.Tensor):
@@ -165,7 +158,7 @@ class ExportModule(export_base.ExportModule, metaclass=abc.ABCMeta):
         input_signature = tf.TensorSpec(
             shape=[self._batch_size] + self._input_image_size +
             [self._num_channels],
-            dtype=tf.int32)
+            dtype=tf.uint8)
         signatures[
             def_name] = self.inference_from_image_tensors.get_concrete_function(
                 input_signature)
@@ -180,14 +173,6 @@ class ExportModule(export_base.ExportModule, metaclass=abc.ABCMeta):
             shape=[self._batch_size], dtype=tf.string)
         signatures[
             def_name] = self.inference_from_tf_example.get_concrete_function(
-                input_signature)
-      elif key == 'image_tensor_with_argmax':
-        input_signature = tf.TensorSpec(
-            shape=[self._batch_size] + self._input_image_size +
-            [self._num_channels],
-            dtype=tf.int32)
-        signatures[
-            def_name] = self.inference_from_image_tensors_with_argmax.get_concrete_function(
                 input_signature)
       else:
         raise ValueError('Unrecognized `input_type`')

--- a/official/vision/beta/serving/export_saved_model.py
+++ b/official/vision/beta/serving/export_saved_model.py
@@ -73,6 +73,8 @@ flags.DEFINE_string(
     'input_image_size', '224,224',
     'The comma-separated string of two integers representing the height,width '
     'of the input to the model.')
+flags.DEFINE_bool('argmax_outputs', False, 'Argmax the last channel of all outputs.')
+flags.DEFINE_bool('visualise_outputs', False, 'Apply colormap to all single channel outputs.')
 
 
 def main(_):
@@ -96,7 +98,9 @@ def main(_):
       checkpoint_path=FLAGS.checkpoint_path,
       export_dir=FLAGS.export_dir,
       export_checkpoint_subdir='checkpoint',
-      export_saved_model_subdir='saved_model')
+      export_saved_model_subdir='saved_model',
+      argmax_outputs=FLAGS.argmax_outputs,
+      visualise_outputs=FLAGS.visualise_outputs)
 
 
 if __name__ == '__main__':

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -1,0 +1,101 @@
+# Lint as: python3
+"""Semantic segmentation input and model functions for serving/inference."""
+
+from typing import Mapping
+
+from absl import logging
+import tensorflow as tf
+
+from official.vision.beta.modeling import factory_multitask
+from official.vision.beta.ops import preprocess_ops
+from official.vision.beta.ops.colormaps import get_colormap
+from official.vision.beta.serving import export_base
+
+
+MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
+STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
+
+
+class MultitaskModule(export_base.ExportModule):
+  """Multitask Module."""
+
+  def __init__(self, 
+               argmax_outputs: bool = False, 
+               visualise_outputs: bool = False, 
+               *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self._argmax_outputs = argmax_outputs
+    self._visualise_outputs = argmax_outputs and visualise_outputs
+
+  def _build_model(self):
+    input_specs = tf.keras.layers.InputSpec(
+        shape=[self._batch_size] + self._input_image_size + [3])
+
+    return factory_multitask.build_multihead_model(
+        input_specs=input_specs,
+        task_config=self.params.task,
+        l2_regularizer=None)
+
+  def _build_inputs(self, image: tf.Tensor) -> tf.Tensor:
+    """Builds classification model inputs for serving."""
+
+    # Normalizes image with mean and std pixel values.
+    image = preprocess_ops.normalize_image(image,
+                                           offset=MEAN_RGB,
+                                           scale=STDDEV_RGB)
+
+    image, _ = preprocess_ops.resize_and_crop_image(
+        image,
+        self._input_image_size,
+        padded_size=self._input_image_size,
+        aug_scale_min=1.0,
+        aug_scale_max=1.0)
+    return image
+
+  def serve(self, images: tf.Tensor) -> Mapping[str, tf.Tensor]:
+    """Cast image to float and run inference.
+
+    Args:
+      images: uint8 Tensor of shape [batch_size, None, None, 3]
+    Returns:
+      Tensor holding classification output logits.
+    """
+    # Removing nest.map_structure, as it adds a while node that is not static
+    if images.shape[0] > 1:
+      with tf.device('cpu:0'):
+        images = tf.cast(images, dtype=tf.float32)
+
+        images = tf.nest.map_structure(
+            tf.identity,
+            tf.map_fn(
+                self._build_inputs, elems=images,
+                fn_output_signature=tf.TensorSpec(
+                    shape=self._input_image_size + [3], dtype=tf.float32),
+                parallel_iterations=32
+                )
+            )
+    else:
+      images = tf.cast(images, dtype=tf.float32)
+      images = tf.squeeze(images)
+      images = self._build_inputs(images)
+      images = tf.expand_dims(images, axis=0)
+
+    outputs = self.inference_step(images)
+    processed_outputs = {}
+    
+    for name, output in outputs.items():
+      
+      if len(output.shape) == 4:
+        output = tf.image.resize(
+          output, self._input_image_size, method='bilinear')
+      
+      if self._argmax_outputs:
+        output = tf.math.argmax(output, -1)
+      processed_outputs[name] = output
+
+      if self._visualise_outputs and len(output.shape) == 3:
+        colormap = get_colormap(cmap_type='cityscapes_int')
+        processed_outputs[name + '_visualised'] = tf.gather(
+          colormap, tf.cast(tf.squeeze(output), tf.int32))
+
+    return processed_outputs

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -11,7 +11,7 @@ from official.vision.beta.ops import preprocess_ops
 from official.vision.beta.ops.colormaps import get_colormap
 from official.vision.beta.serving import export_base
 
-
+# RGB mean and stddev from ImageNet
 MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
 STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
 


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Add serving definition to export multihead model.
Improved on code design for getting visualised mask and class mask instead of raw probabilities.

How was it resolved/added?
Instead of modifying base code and adding a custom signature, visualising the mask or getting class mask is toggled with flags in the serving definition.

Add a Screenshot if there are changes to the UI

## Issue reference

Please reference the issue this PR will close: #_[issue number]_
Related to #1.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc

# Checklist
- [ ] I have not cleaned up my code. Forgive the minor errors
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [ ] I have commented my code, particularly in hard-to-understand areas
