### PR TITLE
Feat/path aggregation network decoder

### DIFF
--- a/official/vision/beta/modeling/backbones/hardnet.py
+++ b/official/vision/beta/modeling/backbones/hardnet.py
@@ -15,7 +15,6 @@ Layers and growth rates:
 PingoLH hardblock-v2 (not pulled) includes conv with biases
 """
 
-import logging
 # Import libraries
 import tensorflow as tf
 
@@ -152,8 +151,6 @@ class HardNet(tf.keras.Model):
     endpoints[str(i+1)] = x
 
     self._output_specs = {l: endpoints[l].get_shape() for l in endpoints}
-    for i, v in endpoints.items():
-      logging.info(f"{i}, {v}, {v.shape}")
 
     super(HardNet, self).__init__(inputs=inputs, outputs=endpoints, **kwargs)
 

--- a/official/vision/beta/modeling/decoders/__init__.py
+++ b/official/vision/beta/modeling/decoders/__init__.py
@@ -19,3 +19,4 @@ from official.vision.beta.modeling.decoders.aspp import ASPP
 from official.vision.beta.modeling.decoders.fpn import FPN
 from official.vision.beta.modeling.decoders.nasfpn import NASFPN
 from official.vision.beta.modeling.decoders.hardnet_decoder import HardNetDecoder
+from official.vision.beta.modeling.decoders.pan import PAN

--- a/official/vision/beta/modeling/decoders/pan.py
+++ b/official/vision/beta/modeling/decoders/pan.py
@@ -1,0 +1,182 @@
+""" Referenced from YOLOv4 implementation on: 
+https://github.com/hunglc007/tensorflow-yolov4-tflite
+
+Path Aggregation Net: https://arxiv.org/abs/1803.01534
+"""
+
+# Import libraries
+import tensorflow as tf
+
+from official.modeling import tf_utils
+
+layers = tf.keras.layers
+
+PANET_SPECS = {
+  3: [256, 128, 256, 512]
+}
+
+
+@tf.keras.utils.register_keras_serializable(package='Vision')
+class PAN(tf.keras.Model):
+  """Decoder for Path-Aggregation Network feature in YOLOv4"""
+
+  def __init__(self,
+               input_specs,
+               routes,
+               activation='relu',
+               use_sync_bn=False,
+               norm_momentum=0.99,
+               norm_epsilon=0.001,
+               kernel_initializer='VarianceScaling',
+               kernel_regularizer=None,
+               bias_regularizer=None,
+               **kwargs):
+    """PAN initialization function.
+    Takes last three levels to perform PAN for YOLOv4.
+    TODO: extend it to support specifying layers
+
+    Args:
+      input_specs: `dict` input specifications. A dictionary consists of
+        {level: TensorShape} from a backbone.
+      routes: number of path aggregation routes
+      activation: `str` name of the activation function.
+      use_sync_bn: if True, use synchronized batch normalization.
+      norm_momentum: `float` normalization omentum for the moving average.
+      norm_epsilon: `float` small float added to variance to avoid dividing by
+        zero.
+      kernel_initializer: kernel_initializer for convolutional layers.
+      kernel_regularizer: tf.keras.regularizers.Regularizer object for Conv2D.
+      bias_regularizer: tf.keras.regularizers.Regularizer object for Conv2d.
+      **kwargs: keyword arguments to be passed.
+    """
+    self._config_dict = {
+        'input_specs': input_specs,
+        'routes': routes,
+        'activation': activation,
+        'use_sync_bn': use_sync_bn,
+        'norm_momentum': norm_momentum,
+        'norm_epsilon': norm_epsilon,
+        'kernel_initializer': kernel_initializer,
+        'kernel_regularizer': kernel_regularizer,
+        'bias_regularizer': bias_regularizer,
+    }
+    if use_sync_bn:
+      self.norm = layers.experimental.SyncBatchNormalization
+    else:
+      self.norm = layers.BatchNormalization
+    activation_fn = layers.Activation(
+        tf_utils.get_activation(activation))
+
+    data_format = tf.keras.backend.image_data_format()
+    if data_format == 'channels_last':
+      self.bn_axis = -1
+    else:
+      self.bn_axis = 1
+    
+    self.norm_momentum = norm_momentum
+    self.norm_epsilon = norm_epsilon
+    self.kernel_initializer = kernel_initializer
+    self.kernel_regularizer = kernel_regularizer
+    self.bias_regularizer = bias_regularizer
+
+    # Build inputs
+    inputs = {}
+    input_specs.pop(list(input_specs.keys())[-2])
+    for level, spec in reversed(input_specs.items()):
+      inputs[level] = tf.keras.Input(shape=spec[1:])
+    
+    routeIdx = [i for i in list(reversed(input_specs.keys()))][:routes]
+    skips = []
+    outputs = {}
+    deep_route = inputs[routeIdx[0]]
+
+    # aggregate decreasing depth, store skips
+    for i in range(routes-1):
+      skips.append(deep_route)
+      shallow_route = inputs[routeIdx[i+1]]
+      filters = PANET_SPECS[routes][i]
+
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+      shallow_route = self.conv(shallow_route, filters=filters, kernels=1)
+
+      deep_route = layers.UpSampling2D(size=2, data_format=data_format)(deep_route)
+      deep_route = tf.concat([deep_route, shallow_route], axis=self.bn_axis)
+
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+      deep_route = self.conv(deep_route, filters=filters*2, kernels=3)
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+      deep_route = self.conv(deep_route, filters=filters*2, kernels=3)
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+    
+    # aggregate increasing depth, pop skips, store outputs
+    for i in range(routes-1):
+      filters = PANET_SPECS[routes][i + routes - 1]
+
+      outputs[i] = self.conv(deep_route, filters=filters, kernels=3)
+      deep_route = self.conv(deep_route, filters=filters, kernels=3, downsample=True)
+      deep_route = tf.concat([deep_route, skips.pop()], axis=self.bn_axis)
+
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+      deep_route = self.conv(deep_route, filters=filters*2, kernels=3)
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+      deep_route = self.conv(deep_route, filters=filters*2, kernels=3)
+      deep_route = self.conv(deep_route, filters=filters, kernels=1)
+
+    outputs[routes-1] = self.conv(deep_route, filters=filters*2, kernels=3)
+
+    super(PAN, self).__init__(inputs=inputs, outputs=outputs, **kwargs)
+
+  def conv(self,
+           inputs: tf.Tensor,
+           filters: int,
+           kernels: int,
+           strides: int = 1,
+           downsample: bool = False):
+    """Creates one group of conv-bn-activation block.
+
+    Args:
+      inputs: A `tf.Tensor` of size `[batch, channels, height, width]`.
+      filters: An `int` number of filters for the first convolution of the
+        layer.
+      kernels: An `int` number representing size of kernel.
+      strides: An `int` stride to use for the first convolution of the layer.
+        If greater than 1, this layer will downsample the input.
+
+    Returns:
+      The output `tf.Tensor` of the block layer.
+    """
+    padding = 'same'
+    if downsample:
+      inputs = layers.ZeroPadding2D(((1, 0), (1, 0)))(inputs)
+      padding = 'valid'
+      strides = 2
+
+    x = layers.Conv2D(
+      filters=filters,
+      kernel_size=kernels,
+      strides=strides,
+      padding=padding,
+      use_bias=False,
+      kernel_initializer=self.kernel_initializer,
+      kernel_regularizer=self.kernel_regularizer,
+      bias_regularizer=self.bias_regularizer)(inputs)
+
+    x = self.norm(
+      axis=self.bn_axis,
+      momentum=self.norm_momentum,
+      epsilon=self.norm_epsilon)(x)
+
+    return layers.Activation(
+        tf_utils.get_activation('relu'))(x)
+
+  def get_config(self):
+    return self._config_dict
+
+  @classmethod
+  def from_config(cls, config, custom_objects=None):
+    return cls(**config)
+
+  @property
+  def output_specs(self):
+    """A dict of {level: TensorShape} pairs for the model output."""
+    return self._output_specs

--- a/official/vision/beta/modeling/decoders/pan_test.py
+++ b/official/vision/beta/modeling/decoders/pan_test.py
@@ -1,0 +1,73 @@
+"""Tests for PANetDecoder."""
+
+# Import libraries
+from absl.testing import parameterized
+import tensorflow as tf
+
+from official.vision.beta.modeling.backbones import hardnet
+from official.vision.beta.modeling.decoders import pan
+
+
+class PANetTest(parameterized.TestCase, tf.test.TestCase):
+
+  @parameterized.parameters(
+      (256, 3),
+      (384, 3),
+      (512, 3)
+  )
+  def test_network_creation(self, input_size, levels):
+    """Test creation of HardnetDecoder."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    
+    backbone = hardnet.HardNet(model_id=70)
+    decoder = pan.PAN(
+        routes=levels,
+        input_specs=backbone.output_specs)
+
+    endpoints = backbone(inputs)
+    feats = decoder(endpoints)
+    feats = list(feats.values())
+
+    channels = pan.PANET_SPECS[levels][0]
+    size = input_size // 2**(6 - levels + 1) # hardnet downsamples 6x
+
+    for i in range(len(feats)):
+      self.assertAllEqual(
+        [1, size, size, channels],
+        feats[i].shape.as_list()
+      )
+      channels *= 2
+      size /= 2
+
+  def test_serialize_deserialize(self):
+    # Create a network object that sets all of its config options.
+    kwargs = dict(
+        input_specs=hardnet.HardNet(model_id=70).output_specs,
+        routes=3,
+        activation='relu',
+        use_sync_bn=False,
+        norm_momentum=0.99,
+        norm_epsilon=0.001,
+        kernel_initializer='VarianceScaling',
+        kernel_regularizer=None,
+        bias_regularizer=None,
+    )
+    network = pan.PAN(**kwargs)
+
+    expected_config = dict(kwargs)
+    self.assertEqual(network.get_config(), expected_config)
+
+    # Create another network object from the first object's config.
+    new_network = pan.PAN.from_config(network.get_config())
+
+    # Validate that the config can be forced to JSON.
+    _ = new_network.to_json()
+
+    # If the serialization was successful, the new config should match the old.
+    self.assertAllEqual(network.get_config(), new_network.get_config())
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
## Description
What feature/issue was addressed?
No strong detector specific decoder.

How was it resolved/added?
Add path aggregation network's decoder used in YOLOv4.

Any dependencies required for the change?

## Issue reference
Please reference the issue this PR will close: #25 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests
Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.
Run the corresponding test file. Test logs:
```
2021-06-30 00:52:18.481444: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
Running tests under Python 3.8.10: /home/whizz/miniconda3/envs/tf24/bin/python                                                                                                                                                      
[ RUN      ] PANetTest.test_network_creation0 (256, 3)  
2021-06-30 00:52:19.928544: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set                                                                                             
2021-06-30 00:52:19.929191: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcuda.so.1
2021-06-30 00:52:20.008890: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 0 with properties:                                                                                                               
pciBusID: 0000:1a:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5                                           
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-06-30 00:52:20.009616: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 1 with properties: 
pciBusID: 0000:67:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-06-30 00:52:20.010286: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 2 with properties: 
pciBusID: 0000:68:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-06-30 00:52:20.010308: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
2021-06-30 00:52:20.012314: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublas.so.11
2021-06-30 00:52:20.012405: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublasLt.so.11
2021-06-30 00:52:20.013074: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcufft.so.10
2021-06-30 00:52:20.013276: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcurand.so.10
2021-06-30 00:52:20.014556: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusolver.so.10
2021-06-30 00:52:20.015056: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusparse.so.11
2021-06-30 00:52:20.015164: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudnn.so.8
2021-06-30 00:52:20.019033: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1862] Adding visible gpu devices: 0, 1, 2
2021-06-30 00:52:20.019332: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical 
operations:  AVX512F
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2021-06-30 00:52:20.020203: I tensorflow/compiler/jit/xla_gpu_device.cc:99] Not creating XLA devices, tf_xla_enable_xla_devices not set
2021-06-30 00:52:20.399034: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 0 with properties: 
pciBusID: 0000:1a:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-06-30 00:52:20.399692: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 1 with properties: 
pciBusID: 0000:67:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-06-30 00:52:20.400267: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 2 with properties: 
pciBusID: 0000:68:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-06-30 00:52:20.400290: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
2021-06-30 00:52:20.400317: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublas.so.11
2021-06-30 00:52:20.400326: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublasLt.so.11
2021-06-30 00:52:20.400335: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcufft.so.10
2021-06-30 00:52:20.400345: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcurand.so.10
2021-06-30 00:52:20.400354: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusolver.so.10
2021-06-30 00:52:20.400363: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusparse.so.11
2021-06-30 00:52:20.400372: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudnn.so.8
2021-06-30 00:52:20.403670: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1862] Adding visible gpu devices: 0, 1, 2
2021-06-30 00:52:20.403697: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
2021-06-30 00:52:21.252598: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1261] Device interconnect StreamExecutor with strength 1 edge matrix:
2021-06-30 00:52:21.252641: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1267]      0 1 2                   
2021-06-30 00:52:21.252647: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1280] 0:   N N N                   
2021-06-30 00:52:21.252650: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1280] 1:   N N N                   
2021-06-30 00:52:21.252653: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1280] 2:   N N N       
2021-06-30 00:52:21.255696: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1406] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 10066 MB memory) -> physical GPU (device: 0, name: GeForce RTX 208
0 Ti, pci bus id: 0000:1a:00.0, compute capability: 7.5)                                                                                                                                                                            
2021-06-30 00:52:21.257247: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1406] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:1 with 10066 MB memory) -> physical GPU (device: 1, name: GeForce RTX 208
0 Ti, pci bus id: 0000:67:00.0, compute capability: 7.5)
2021-06-30 00:52:21.258666: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1406] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:2 with 10045 MB memory) -> physical GPU (device: 2, name: GeForce RTX 208
0 Ti, pci bus id: 0000:68:00.0, compute capability: 7.5)                                                                                                                                                                            
/home/whizz/miniconda3/envs/tf24/lib/python3.8/site-packages/tensorflow/python/keras/engine/functional.py:592: UserWarning: Input dict contained keys ['4'] which did not match any model input. They will be ignored by the model.
  warnings.warn(                                                                                                  
INFO:tensorflow:time(__main__.PANetTest.test_network_creation0 (256, 3)): 2.5s                 
I0630 00:52:22.422254 140013753918272 test_util.py:2075] time(__main__.PANetTest.test_network_creation0 (256, 3)): 2.5s
[       OK ] PANetTest.test_network_creation0 (256, 3)                                                            
[ RUN      ] PANetTest.test_network_creation1 (384, 3)                                                            
INFO:tensorflow:time(__main__.PANetTest.test_network_creation1 (384, 3)): 0.84s                                                                                                                                                     
I0630 00:52:23.266282 140013753918272 test_util.py:2075] time(__main__.PANetTest.test_network_creation1 (384, 3)): 0.84s
[       OK ] PANetTest.test_network_creation1 (384, 3)                                                            
[ RUN      ] PANetTest.test_network_creation2 (512, 3)                                                                                                                                                                              
INFO:tensorflow:time(__main__.PANetTest.test_network_creation2 (512, 3)): 0.84s                                                                                                                                                     
I0630 00:52:24.110806 140013753918272 test_util.py:2075] time(__main__.PANetTest.test_network_creation2 (512, 3)): 0.84s                         
[       OK ] PANetTest.test_network_creation2 (512, 3)                                                                                                                                                                              
[ RUN      ] PANetTest.test_serialize_deserialize                                                                                                                                                                                   
INFO:tensorflow:time(__main__.PANetTest.test_serialize_deserialize): 1.01s                                                                                                                                                          
I0630 00:52:25.122276 140013753918272 test_util.py:2075] time(__main__.PANetTest.test_serialize_deserialize): 1.01s                              
[       OK ] PANetTest.test_serialize_deserialize                                                                                                                                                                                   
[ RUN      ] PANetTest.test_session                                                                                                                                                                                                 
[  SKIPPED ] PANetTest.test_session                                                                                                                                                                                                 
----------------------------------------------------------------------
Ran 5 tests in 5.203s                                                                                             
                                                                                                                                                                                                                                    
OK (skipped=1)                                                                             
```

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.