### PR TITLE
[Feature] Add YOLOv3 head

### DIFF
--- a/official/vision/beta/modeling/decoders/pan.py
+++ b/official/vision/beta/modeling/decoders/pan.py
@@ -12,6 +12,7 @@ from official.modeling import tf_utils
 layers = tf.keras.layers
 
 PANET_SPECS = {
+  2: [256, 256],
   3: [256, 128, 256, 512]
 }
 
@@ -64,8 +65,7 @@ class PAN(tf.keras.Model):
       self.norm = layers.experimental.SyncBatchNormalization
     else:
       self.norm = layers.BatchNormalization
-    activation_fn = layers.Activation(
-        tf_utils.get_activation(activation))
+    self.activation_fn = tf_utils.get_activation(activation)
 
     data_format = tf.keras.backend.image_data_format()
     if data_format == 'channels_last':
@@ -166,8 +166,7 @@ class PAN(tf.keras.Model):
       momentum=self.norm_momentum,
       epsilon=self.norm_epsilon)(x)
 
-    return layers.Activation(
-        tf_utils.get_activation('relu'))(x)
+    return self.activation_fn(x)
 
   def get_config(self):
     return self._config_dict

--- a/official/vision/beta/modeling/decoders/pan_test.py
+++ b/official/vision/beta/modeling/decoders/pan_test.py
@@ -13,7 +13,8 @@ class PANetTest(parameterized.TestCase, tf.test.TestCase):
   @parameterized.parameters(
       (256, 3),
       (384, 3),
-      (512, 3)
+      (512, 3),
+      (256, 2)
   )
   def test_network_creation(self, input_size, levels):
     """Test creation of HardnetDecoder."""


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Add YOLOv3 detector head, used in v4 and v5 versions.

How was it resolved/added?

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #24.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.
Run corresponding test to get following logs.
```
Running tests under Python 3.8.10: /home/whizz/miniconda3/envs/tf24/bin/python                                                                                                                                             [ RUN      ] YOLOv3HeadTest.test_forward0 (3, 256, [8, 16, 32], [12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401], [1.2, 1.1, 1.05])
2021-07-01 17:05:54.205166: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set                                                                                    2021-07-01 17:05:54.205838: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcuda.so.1
2021-07-01 17:05:54.252658: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 0 with properties:                           
pciBusID: 0000:1a:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5                                                                                                                                                    
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s                                                                                                                            
2021-07-01 17:05:54.253317: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 1 with properties:                                                                                                       pciBusID: 0000:67:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s                                                                                                                            
2021-07-01 17:05:54.253961: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 2 with properties:            
pciBusID: 0000:68:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5                                                                                                                                                    
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s                                                                                                                            
2021-07-01 17:05:54.253984: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
2021-07-01 17:05:54.255965: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublas.so.11
2021-07-01 17:05:54.256036: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublasLt.so.11
2021-07-01 17:05:54.256704: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcufft.so.10
2021-07-01 17:05:54.256896: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcurand.so.10
2021-07-01 17:05:54.258164: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusolver.so.10
2021-07-01 17:05:54.258659: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusparse.so.11
2021-07-01 17:05:54.258770: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudnn.so.8
2021-07-01 17:05:54.262368: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1862] Adding visible gpu devices: 0, 1, 2
2021-07-01 17:05:54.262621: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-
critical operations:  AVX512F
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2021-07-01 17:05:54.263465: I tensorflow/compiler/jit/xla_gpu_device.cc:99] Not creating XLA devices, tf_xla_enable_xla_devices not set                                                                                    
2021-07-01 17:05:54.642546: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 0 with properties:                                                                                                       
pciBusID: 0000:1a:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5                                      
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s              
2021-07-01 17:05:54.643162: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 1 with properties:                                                                                                       
pciBusID: 0000:67:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5                                      
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s
2021-07-01 17:05:54.643738: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1720] Found device 2 with properties:                                                                                                       
pciBusID: 0000:68:00.0 name: GeForce RTX 2080 Ti computeCapability: 7.5                                      
coreClock: 1.545GHz coreCount: 68 deviceMemorySize: 10.76GiB deviceMemoryBandwidth: 573.69GiB/s              
2021-07-01 17:05:54.643763: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0                                                                          
2021-07-01 17:05:54.643788: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublas.so.11                                                                            
2021-07-01 17:05:54.643797: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublasLt.so.11                                                                          
2021-07-01 17:05:54.643806: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcufft.so.10                                                                             
2021-07-01 17:05:54.643816: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcurand.so.10                                                                            
2021-07-01 17:05:54.643824: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusolver.so.10                                                                          
2021-07-01 17:05:54.643832: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcusparse.so.11                                                                          
2021-07-01 17:05:54.643842: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudnn.so.8                                                                              
2021-07-01 17:05:54.647160: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1862] Adding visible gpu devices: 0, 1, 2                                                                                                   
2021-07-01 17:05:54.647187: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0                                                                          
2021-07-01 17:05:55.528259: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1261] Device interconnect StreamExecutor with strength 1 edge matrix:                                                                       
2021-07-01 17:05:55.528299: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1267]      0 1 2              
2021-07-01 17:05:55.528305: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1280] 0:   N N N              
2021-07-01 17:05:55.528308: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1280] 1:   N N N              
2021-07-01 17:05:55.528311: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1280] 2:   N N N 
2021-07-01 17:05:55.531363: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1406] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 10066 MB memory) -> physical GPU (device: 0, name: GeForce RTX 2080 Ti, pci bus id: 0000:1a:00.0, compute capability: 7.5)                                                                                                                                                          
2021-07-01 17:05:55.532918: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1406] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:1 with 10066 MB memory) -> physical GPU (device: 1, name: GeForce RTX 2080 Ti, pci bus id: 0000:67:00.0, compute capability: 7.5)                                                                                                                                                          
2021-07-01 17:05:55.534257: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1406] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:2 with 10045 MB memory) -> physical GPU (device: 2, name: GeForce RTX 2080 Ti, pci bus id: 0000:68:00.0, compute capability: 7.5)                                                                                                                                                          
2021-07-01 17:05:55.621180: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublas.so.11
2021-07-01 17:05:55.943018: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcublasLt.so.11                                                                          
INFO:tensorflow:time(__main__.YOLOv3HeadTest.test_forward0 (3, 256, [8, 16, 32], [12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401], [1.2, 1.1, 1.05])): 1.76s                                
I0701 17:05:55.955501 140530753405760 test_util.py:2075] time(__main__.YOLOv3HeadTest.test_forward0 (3, 256, [8, 16, 32], [12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401], [1.2, 1.1, 1.05])): 1.76s                                                                                                    
[       OK ] YOLOv3HeadTest.test_forward0 (3, 256, [8, 16, 32], [12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401], [1.2, 1.1, 1.05])                                                         
[ RUN      ] YOLOv3HeadTest.test_forward1 (2, 256, [16, 32], [23, 27, 37, 58, 81, 82, 81, 82, 135, 169, 344, 319], [1.05, 1.05])
INFO:tensorflow:time(__main__.YOLOv3HeadTest.test_forward1 (2, 256, [16, 32], [23, 27, 37, 58, 81, 82, 81, 82, 135, 169, 344, 319], [1.05, 1.05])): 0.01s                                                                  
I0701 17:05:55.964796 140530753405760 test_util.py:2075] time(__main__.YOLOv3HeadTest.test_forward1 (2, 256, [16, 32], [23, 27, 37, 58, 81, 82, 81, 82, 135, 169, 344, 319], [1.05, 1.05])): 0.01s                         
[       OK ] YOLOv3HeadTest.test_forward1 (2, 256, [16, 32], [23, 27, 37, 58, 81, 82, 81, 82, 135, 169, 344, 319], [1.05, 1.05])                 
[ RUN      ] YOLOv3HeadTest.test_serialize_deserialize                                                                                                                                                                     
INFO:tensorflow:time(__main__.YOLOv3HeadTest.test_serialize_deserialize): 0.0s                                                                                                                                             
I0701 17:05:55.966394 140530753405760 test_util.py:2075] time(__main__.YOLOv3HeadTest.test_serialize_deserialize): 0.0s                       
[       OK ] YOLOv3HeadTest.test_serialize_deserialize                                                                                                                                                                     
[ RUN      ] YOLOv3HeadTest.test_session                                                                                                                                                                                   
[  SKIPPED ] YOLOv3HeadTest.test_session                                                                                                                                                                                   
----------------------------------------------------------------------                                                                                                                                                     
Ran 4 tests in 1.768s                                                                                                                                                                                                      
                                                                                                                                                                                                                           
OK (skipped=1)
```
## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.