### PR TITLE
[Bug] YOLOv3 head anchor calculation

### DIFF
--- a/official/vision/beta/modeling/factory.py
+++ b/official/vision/beta/modeling/factory.py
@@ -363,7 +363,7 @@ def build_yolo_model(
   head = instance_heads.YOLOv3Head(
       levels=len(decoder.output_specs),
       num_classes=model_config.num_classes,
-      input_size=head_config.input_size,
+      input_size=model_config.input_size,
       strides=head_config.strides,
       anchor_per_scale=head_config.anchor_per_scale,
       anchors=head_config.anchors,

--- a/official/vision/beta/modeling/factory.py
+++ b/official/vision/beta/modeling/factory.py
@@ -361,9 +361,11 @@ def build_yolo_model(
   head_config = model_config.head
 
   head = instance_heads.YOLOv3Head(
+      levels=len(decoder.output_specs),
       num_classes=model_config.num_classes,
       input_size=head_config.input_size,
       strides=head_config.strides,
+      anchor_per_scale=head_config.anchor_per_scale,
       anchors=head_config.anchors,
       xy_scale=head_config.xy_scale,
       kernel_regularizer=l2_regularizer)


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Calculation using bbox anchors is wrong.
Unable to build ops during inference.

How was it resolved/added?
Fixed by adding parameters and reshaping of anchor tensor.
Move ops building to initialisation.

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #_[issue number]_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.
Run corresponding test.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.