### PR TITLE
[Bug] Standardise bounding box type

### DIFF
--- a/official/vision/beta/dataloaders/yolo_input.py
+++ b/official/vision/beta/dataloaders/yolo_input.py
@@ -189,20 +189,24 @@ class Parser(parser.Parser):
       image = tf.image.random_hue(image=image, max_delta=.3)  # Hue
 
     image = tf.clip_by_value(image, 0.0, 1.0)
+    boxes = box_ops.yxyx_to_xcycwh(boxes)
     boxes = tf.concat([boxes, data['classes'][:, tf.newaxis]], axis=-1)
 
-    result = yolo_ops.preprocess_true_boxes(
+    labels, bboxes = yolo_ops.preprocess_true_boxes(
       bboxes=boxes,
       train_output_sizes=self.train_output_sizes,
       anchor_per_scale=self.anchor_per_scale,
       num_classes=self.num_classes,
       max_bbox_per_scale=self.max_bbox_per_scale,
       strides=self.strides,
-      anchors=self.anchors,
-      is_bbox_in_pixels=self.is_bbox_in_pixels,
-      is_xywh=self.is_xywh)
+      anchors=self.anchors)
+    
+    targets = {
+      'labels': labels,
+      'bboxes': bboxes
+    }
 
-    return image, *result
+    return image, targets
 
   def _parse_eval_data(self, data):
     """Parses data for training and evaluation."""

--- a/official/vision/beta/dataloaders/yolo_input.py
+++ b/official/vision/beta/dataloaders/yolo_input.py
@@ -7,13 +7,15 @@ import numpy as np
 from official.vision.beta.dataloaders import decoder
 from official.vision.beta.dataloaders import parser
 from official.vision.beta.ops import augment, preprocess_ops, yolo_ops
-from official.vision.beta.projects.yolo.ops import preprocess_ops as yolo_preprocess_ops
+from official.vision.beta.projects.yolo.ops import box_ops, preprocess_ops as yolo_preprocess_ops
 
 
 class Decoder(decoder.Decoder):
   """A tf.Example decoder for yolo task."""
 
-  def __init__(self, is_bbox_in_pixels=False):
+  def __init__(self, 
+               is_bbox_in_pixels=False, 
+               is_xywh=False):
     self._keys_to_features = {
         'image/encoded': tf.io.FixedLenFeature((), tf.string, default_value=''),
         'image/height': tf.io.FixedLenFeature((), tf.int64, default_value=0),
@@ -26,6 +28,7 @@ class Decoder(decoder.Decoder):
     }
 
     self.is_bbox_in_pixels = is_bbox_in_pixels
+    self.is_xywh = is_xywh
   
   def _decode_image(self, parsed_tensors):
     """Decodes the image and set its static shape."""
@@ -45,8 +48,12 @@ class Decoder(decoder.Decoder):
       y = y * tf.cast(parsed_tensors['image/height'], tf.float32)
       w = w * tf.cast(parsed_tensors['image/width'], tf.float32)
       h = h * tf.cast(parsed_tensors['image/height'], tf.float32)
+    
+    bbox = tf.stack([x, y, w, h], axis=-1)
+    if self.is_xywh:
+      bbox = box_ops.xcycwh_to_yxyx(bbox)
 
-    return tf.stack([x, y, w, h], axis=-1)
+    return bbox
 
   def decode(self, serialized_example):
     parsed_tensors = tf.io.parse_single_example(
@@ -86,8 +93,6 @@ class Parser(parser.Parser):
                max_bbox_per_scale: int,
                strides: List,
                anchors: List,
-               is_bbox_in_pixels: bool,
-               is_xywh: bool,
                aug_policy: Optional[str] = None,
                randaug_magnitude: Optional[int] = 10,
                randaug_available_ops: Optional[List[str]] = None,
@@ -99,6 +104,8 @@ class Parser(parser.Parser):
                aug_rand_hue=True,
                dtype='float32'):
     """Initializes parameters for parsing annotations in the dataset.
+    !!! Augmentation ops assumes that boxes are yxyx format, non-normalized
+      (top left, bottom right coords) in pixels.
 
     Args:
       output_size: `Tensor` or `list` for [height, width] of output image. The
@@ -110,8 +117,6 @@ class Parser(parser.Parser):
       strides: `List[int]` of output strides, ratio of input to output resolution.
       anchors: `tf.Tensor` of shape (None, anchor_per_scale, 2) denothing positions
         of anchors
-      is_bbox_in_pixels: `bool`, true if bounding box values are in pixels
-      is_xywh: `bool`, true if bounding box values are in (x, y, width, height) format
       aug_policy: `str`, augmentation policies. None or 'randaug'. TODO support 'autoaug'
       randaug_magnitude: `int`, magnitude of the randaugment policy.
       randaug_available_ops: `List[str]`, specify augmentations for randaug
@@ -135,9 +140,8 @@ class Parser(parser.Parser):
     self.max_bbox_per_scale = max_bbox_per_scale
     self.strides = strides
     self.anchors = tf.constant(anchors, dtype=tf.float32)
-    self.anchors = tf.reshape(self.anchors, [int(len(anchors)/6), 3, 2])
-    self.is_bbox_in_pixels = is_bbox_in_pixels
-    self.is_xywh = is_xywh
+    self.anchors = tf.reshape(self.anchors, [
+      int(len(anchors)/self.anchor_per_scale/2), self.anchor_per_scale, 2])
 
     # Data augmentation.
     self._aug_rand_hflip = aug_rand_hflip
@@ -162,16 +166,21 @@ class Parser(parser.Parser):
     self._dtype = dtype
 
   def _parse_train_data(self, data):
-    """Parses data for training and evaluation."""
+    """Parses data for training and evaluation.
+    !!! All augmentations and transformations are on bboxes with format
+      (ymin, xmin, ymax, xmax). Required to do the appropriate transformations.
+    """
     image, boxes = data['image'], data['boxes']
 
     image, boxes = yolo_preprocess_ops.fit_preserve_aspect_ratio(
         image, boxes, target_dim=self._input_size[0])
 
-    if self._aug_rand_hflip:
-      image, boxes, _ = preprocess_ops.random_horizontal_flip(image, boxes)
+    #TODO(ruien): this only works on normalized bboxes
+    # if self._aug_rand_hflip:
+    #   image, boxes, _ = preprocess_ops.random_horizontal_flip(image, boxes)
     
     #TODO(ruien): implement random zoom
+    #TODO(ruien): implement jitter boxes
 
     if self._aug_jitter_im != 0.0:
       image, boxes = yolo_preprocess_ops.random_translate(

--- a/official/vision/beta/ops/yolo_ops_test.py
+++ b/official/vision/beta/ops/yolo_ops_test.py
@@ -8,6 +8,7 @@ import numpy as np
 import tensorflow as tf
 
 from official.vision.beta.ops import yolo_ops
+from official.vision.beta.projects.yolo.ops import box_ops
 
 
 class YoloOpsTest(parameterized.TestCase, tf.test.TestCase):
@@ -32,7 +33,13 @@ class YoloOpsTest(parameterized.TestCase, tf.test.TestCase):
         [369, 226, 389, 263,   0],
         [135, 225, 180, 355,   0],
         [171, 229, 185, 311,   0],
-        [  0, 216, 415, 363,   0]])
+        [  0, 216, 415, 363,   0]]) # x1, y1, x2, y2, class
+    
+    classes = bboxes[:, 4]
+    bboxes = tf.stack([bboxes[:, 1], bboxes[:, 0], bboxes[:, 3], bboxes[:, 2]], axis=-1) #yxyx
+    bboxes = box_ops.yxyx_to_xcycwh(tf.cast(bboxes, tf.float32))
+    inputs = tf.concat([bboxes, tf.cast(classes[:, tf.newaxis], tf.float32)], axis=-1)
+    
     train_output_sizes=tf.constant([52,26,13])
     anchor_per_scale = 3
     num_classes = 80
@@ -41,13 +48,13 @@ class YoloOpsTest(parameterized.TestCase, tf.test.TestCase):
     anchors = tf.constant([[[ 12,  16], [ 19,  36], [ 40,  28]],[[ 36,  75], [ 76,  55], [ 72, 146]],[[142, 110], [192, 243], [459, 401]]])
 
     result = yolo_ops.preprocess_true_boxes(
-      bboxes=bboxes,
+      bboxes=inputs,
       train_output_sizes=train_output_sizes,
       anchor_per_scale=anchor_per_scale,
       num_classes=num_classes,
       max_bbox_per_scale=max_bbox_per_scale,
       strides=strides,
-      anchors=anchors)
+      anchors=anchors) # only takes xywh
 
     target_labels, target_bboxes = result
 
@@ -76,10 +83,10 @@ class YoloOpsTest(parameterized.TestCase, tf.test.TestCase):
         37. , 157.5, 290. ,  45. , 130. , 178. , 270. ,  14. ,  82. ,
        207.5, 289.5, 415. , 147. ])
     
-    self.assertAllEqual(
+    self.assertAllClose(
       tf.boolean_mask(target_labels[0], tf.greater(target_labels[0], 0.5)), 
       groundtruth_label_small_bbox)
-    self.assertAllEqual(
+    self.assertAllClose(
       tf.boolean_mask(target_bboxes[0], tf.greater(target_bboxes[0], 0.5)),
       groundtruth_small_bbox)
     self.assertAllEqual(target_labels[0].shape, np.array([52, 52, 3, 85]))


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Different bbox operations assume diffferent bbox formats. 

How was it resolved/added?
Standardise to 
- Decode to (ymin, ymax, xmin, xmax), unnormalized format
- Preprocessing to perform on (center x, center y, width, height), unnormalized format.

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #_[issue number]_
First big step to #42. Will not close it until bounding boxes are visualised and correct.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.
Run corresponding yolo ops test.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.