### PR TITLE
[Bug] New bbox resize op

### DIFF
--- a/official/vision/beta/dataloaders/yolo_input.py
+++ b/official/vision/beta/dataloaders/yolo_input.py
@@ -165,8 +165,13 @@ class Parser(parser.Parser):
     """Parses data for training and evaluation."""
     image, boxes = data['image'], data['boxes']
 
-    image, boxes = yolo_preprocess_ops.fit_preserve_aspect_ratio(
-        image, boxes, target_dim=self._input_size[0])
+    image, boxes = yolo_ops.resize_image_and_bboxes(
+      image=image, 
+      bboxes=boxes, 
+      target_size=self._input_size[:2], 
+      preserve_aspect_ratio=False,
+      image_height=data['height'],
+      image_width=data['width'])
 
     if self._aug_rand_hflip:
       image, boxes, _ = preprocess_ops.random_horizontal_flip(image, boxes)

--- a/official/vision/beta/dataloaders/yolo_input.py
+++ b/official/vision/beta/dataloaders/yolo_input.py
@@ -164,6 +164,7 @@ class Parser(parser.Parser):
   def _parse_train_data(self, data):
     """Parses data for training and evaluation."""
     image, boxes = data['image'], data['boxes']
+    image /= 255
 
     image, boxes = yolo_ops.resize_image_and_bboxes(
       image=image, 
@@ -171,7 +172,8 @@ class Parser(parser.Parser):
       target_size=self._input_size[:2], 
       preserve_aspect_ratio=False,
       image_height=data['height'],
-      image_width=data['width'])
+      image_width=data['width'],
+      image_normalized=True)
 
     if self._aug_rand_hflip:
       image, boxes, _ = preprocess_ops.random_horizontal_flip(image, boxes)

--- a/official/vision/beta/ops/yolo_ops.py
+++ b/official/vision/beta/ops/yolo_ops.py
@@ -13,7 +13,8 @@ def resize_image_and_bboxes(image: tf.Tensor,
                             target_size: Tuple[int, int],
                             preserve_aspect_ratio: bool = False,
                             image_height: int = None,
-                            image_width: int = None):
+                            image_width: int = None,
+                            image_normalized: bool = True):
   """
   Args:
     image: `tf.Tensor` of shape (None, 5), denoting (x, y, w, h, class), non-normalized
@@ -22,6 +23,8 @@ def resize_image_and_bboxes(image: tf.Tensor,
     preserve_aspect_ratio: `bool`, true to preserve image aspect ratio
     image_height: `int`, height of image
     image_width: `int`, width of image
+  
+  !! assumes image is normalized to 0-1
   """
   target_height, target_width = target_size
   if image_height is None or image_width is None:
@@ -32,7 +35,14 @@ def resize_image_and_bboxes(image: tf.Tensor,
     clip_size = max(image_height, image_width)
     pad_height = (clip_size - image_height)//2
     pad_width = (clip_size - image_width)//2
-    image = tf.image.pad_to_bounding_box(image, pad_height, pad_width, clip_size, clip_size)
+
+    if image_normalized:
+      image = tf.pad(image, 
+        tf.constant([[pad_height, pad_height], [pad_width, pad_width], [0, 0]]), 
+        constant_values=0.5)
+    else:
+      image = tf.image.pad_to_bounding_box(
+        image, pad_height, pad_width, clip_size, clip_size)
 
     scale = min(scale_height, scale_width)
     bboxes *= scale

--- a/official/vision/beta/ops/yolo_ops.py
+++ b/official/vision/beta/ops/yolo_ops.py
@@ -8,7 +8,47 @@ import numpy as np
 import tensorflow as tf
 
 
-def preprocess_true_boxes(bboxes,
+def resize_image_and_bboxes(image: tf.Tensor, 
+                            bboxes: tf.Tensor, 
+                            target_size: Tuple[int, int],
+                            preserve_aspect_ratio: bool = False,
+                            image_height: int = None,
+                            image_width: int = None):
+  """
+  Args:
+    image: `tf.Tensor` of shape (None, 5), denoting (x, y, w, h, class), non-normalized
+    bboxes: `tf.Tensor` of shape (None, 4), denoting (ymin, xmin, ymax, xmax), non-normalized
+    target: `Tuple[int,int]`, denoting height and width of resulting image/bbox
+    preserve_aspect_ratio: `bool`, true to preserve image aspect ratio
+    image_height: `int`, height of image
+    image_width: `int`, width of image
+  """
+  target_height, target_width = target_size
+  if image_height is None or image_width is None:
+    image_height, image_width, _ = image.shape
+  scale_height, scale_width = target_height / image_height, target_width / image_width
+
+  if preserve_aspect_ratio:
+    clip_size = max(image_height, image_width)
+    pad_height = (clip_size - image_height)//2
+    pad_width = (clip_size - image_width)//2
+    image = tf.image.pad_to_bounding_box(image, pad_height, pad_width, clip_size, clip_size)
+
+    scale = min(scale_height, scale_width)
+    bboxes *= scale
+    offset = tf.stack([pad_height, pad_width, pad_height, pad_width], axis=-1)
+    bboxes += tf.cast(offset, tf.float32)
+  
+  else:
+    scale = tf.stack([scale_height, scale_width, scale_height, scale_width], axis=-1)
+    bboxes *= tf.cast(scale, tf.float32)
+
+  image = tf.image.resize(image, target_size)
+
+  return image, bboxes
+
+
+def preprocess_true_boxes(bboxes: tf.Tensor,
                           train_output_sizes: List[int],
                           anchor_per_scale: int,
                           num_classes: int,

--- a/official/vision/beta/ops/yolo_ops_test.py
+++ b/official/vision/beta/ops/yolo_ops_test.py
@@ -12,6 +12,37 @@ from official.vision.beta.ops import yolo_ops
 
 class YoloOpsTest(parameterized.TestCase, tf.test.TestCase):
   
+  @parameterized.parameters(
+    (
+      [0.456250, 0.415104, 0.176563, 0.171875], # xywh in normalised form
+      [84.26663, 94.19994, 128.26663, 139.40007], # yxyx in pixels
+      960, 1280, (256, 256), False
+    ),
+    (
+      [0.464453, 0.517188, 0.249219, 0.065625], # xywh in normalised form
+      [253.00009, 86.99993, 265.6001, 150.8], # yxyx in pixels
+      960, 1280, (256, 256), True
+    )
+  )
+  def testResizeImageBoxes(self, 
+                           bbox, 
+                           bbox_result, 
+                           height, 
+                           width, 
+                           target_dim, 
+                           preserve_aspect_ratio):
+    image = tf.random.uniform((height, width, 3))
+    bbox = [bbox[0] * width, bbox[1] * height, bbox[2] * width, bbox[3] * height]
+    bbox = box_ops.xcycwh_to_yxyx(bbox)
+    new_image, new_bbox = yolo_ops.resize_image_and_bboxes(
+      image=image, 
+      bboxes=bbox, 
+      target_size=target_dim, 
+      preserve_aspect_ratio=preserve_aspect_ratio)
+    
+    self.assertAllClose(new_bbox, bbox_result)
+    self.assertAllEqual(new_image.shape[:2], target_dim)
+
   def testYoloPreprocessTrueBoxes(self):
     bboxes = tf.constant([
         [ 40,  79, 109, 144,  74],


### PR DESCRIPTION
## Description
What feature/issue was addressed?
- Bbox resizing op from branch purdue/yolo does not work
- Resizing is required as the preprocessing for yolo requires it to be scaled to expected input size.

How was it resolved/added?
- Added a new one and tested it.

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #_[issue number]_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.
Run relevant test.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.