### PR TITLE
[Bug] Standardise bbox types during augmentation.

### DIFF
--- a/official/vision/beta/configs/experiments/yolo/yolo_scooter_gpu.yaml
+++ b/official/vision/beta/configs/experiments/yolo/yolo_scooter_gpu.yaml
@@ -42,14 +42,16 @@ task:
 
     dtype: 'float32'
     aug_rand_hflip: true
-    aug_jitter_im: 0.1
-    aug_rand_saturation: true
-    aug_rand_brightness: true
-    aug_rand_zoom: true
-    aug_rand_hue: true
+    aug_scale_min: 0.5
+    aug_scale_max: 2.0
+    preserve_aspect_ratio: false
+
+    aug_jitter_im: 0.1 # proportion of image
+    aug_jitter_boxes: 0.025 # magnitude of noise (usually 0.0-0.1)
+
     aug_policy: randaug
     randaug_magnitude: 5 # 5-10 for image classification
-    randaug_available_ops: ['AutoContrast', 'Equalize', 'Invert', 'Rotate', 'Posterize', 'Solarize', 'Color', 'Contrast', 'Brightness', 'Sharpness', 'Cutout', 'SolarizeAdd']
+    randaug_available_ops: ['AutoContrast', 'Equalize', 'Invert', 'Posterize', 'Solarize', 'Color', 'Contrast', 'Brightness', 'Sharpness', 'Cutout', 'SolarizeAdd']
   validation_data:
     output_size: [256, 256]
     input_path: 'D:/data/whizz_tf/detect_env*'

--- a/official/vision/beta/configs/yolo.py
+++ b/official/vision/beta/configs/yolo.py
@@ -23,14 +23,19 @@ class DataConfig(cfg.DataConfig):
   shuffle_buffer_size: int = 1000
   cycle_length: int = 10
   aug_rand_hflip: bool = True
+  aug_scale_min: float = 1.0
+  aug_scale_max: float = 1.0
+  preserve_aspect_ratio: bool = True
   aug_jitter_im: float = 0.1
-  aug_rand_saturation: bool = True
-  aug_rand_brightness: bool = True
-  aug_rand_zoom: bool = True
-  aug_rand_hue: bool = True
+  aug_jitter_boxes: float = 0.025
   aug_policy: Optional[str] = None  # None, 'autoaug', or 'randaug'
   randaug_magnitude: Optional[int] = 10
-  randaug_available_ops: Optional[List[str]] = None
+
+  # visual randaugment only, since bbox augmentation ops not implemented well ye
+  randaug_available_ops: Optional[List[str]] = dataclasses.field(default_factory=lambda:
+    ['AutoContrast', 'Equalize', 'Invert', 'Posterize', 
+    'Solarize', 'Color', 'Contrast', 'Brightness', 'Sharpness', 
+    'Cutout', 'SolarizeAdd'])
   drop_remainder: bool = True
   file_type: str = 'tfrecord'
 

--- a/official/vision/beta/tasks/yolo.py
+++ b/official/vision/beta/tasks/yolo.py
@@ -99,11 +99,11 @@ class YoloTask(base_task.Task):
         randaug_magnitude=params.randaug_magnitude,
         randaug_available_ops=params.randaug_available_ops,
         aug_rand_hflip=params.aug_rand_hflip,
+        aug_scale_min=params.aug_scale_min,
+        aug_scale_max=params.aug_scale_max,
+        preserve_aspect_ratio=params.preserve_aspect_ratio,
         aug_jitter_im=params.aug_jitter_im,
-        aug_rand_saturation=params.aug_rand_saturation,
-        aug_rand_brightness=params.aug_rand_brightness,
-        aug_rand_zoom=params.aug_rand_zoom,
-        aug_rand_hue=params.aug_rand_hue,
+        aug_jitter_boxes=params.aug_jitter_boxes,
         dtype=params.dtype)
 
     reader = input_reader_factory.input_reader_generator(


### PR DESCRIPTION
## Description
What feature/issue was addressed?

Rebased and recreating PR.
Augmentation ops scattered in the repo assume different bounding box types.

How was it resolved/added?

Tried to standardize or add pre/post processing for ops to work.
Use RandAugment for image augmentation (used for segmentation).

![image](https://user-images.githubusercontent.com/57937231/124788751-3c90e680-df7c-11eb-97eb-af27d796529d.png)
![image](https://user-images.githubusercontent.com/57937231/124788724-36026f00-df7c-11eb-89b7-fb8bd516fa4b.png)


Any dependencies required for the change?

No

## Issue reference

Please reference the issue this PR will close: #42.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.


## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.