### PR TITLE
[Bug] Multibatch visualisation of bbox for YOLO

### DIFF
--- a/official/vision/beta/dataloaders/yolo_input.py
+++ b/official/vision/beta/dataloaders/yolo_input.py
@@ -220,16 +220,24 @@ class Parser(parser.Parser):
       strides=self.strides,
       anchors=self.anchors)
     
+    # pad / limit to 10 boxes for constant size
+    raw_bboxes = boxes
+    num_bboxes = tf.shape(raw_bboxes)[0]
+    if num_bboxes > 10:
+      raw_bboxes = raw_bboxes[:, :10]
+    else:
+      paddings = tf.stack([0, 10-num_bboxes], axis=-1)
+      paddings = tf.stack([paddings, [0,0]], axis=0)
+      raw_bboxes = tf.pad(raw_bboxes, paddings)
+
     targets = {
       'labels': labels,
       'bboxes': bbox_labels,
-      'raw_bboxes': boxes
+      'raw_bboxes': raw_bboxes
     }
 
     return image, targets
 
   def _parse_eval_data(self, data):
     """Parses data for training and evaluation."""
-    image, bboxes = self._prepare_image_and_bbox(data)
-
-    return image, bboxes
+    pass

--- a/official/vision/beta/tasks/yolo.py
+++ b/official/vision/beta/tasks/yolo.py
@@ -77,7 +77,7 @@ class YoloTask(base_task.Task):
   def build_inputs(self,
                    params: exp_cfg.DataConfig,
                    input_context: Optional[tf.distribute.InputContext] = None):
-    """Builds classification input."""
+    """Builds yolo input."""
 
     if params.tfds_name:
       raise ValueError('TFDS {} is not supported'.format(params.tfds_name))


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Unable to train YOLO on batch size > 1 due to inconsistent shape of bounding boxes tensor for visualisation.

How was it resolved/added?
Padded or trimmed to 10 bounding boxes for visualising.

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #59.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.