### PR TITLE
[Bug] Numerical stability when calculating bbox iou

### DIFF
--- a/official/vision/beta/ops/yolo_ops.py
+++ b/official/vision/beta/ops/yolo_ops.py
@@ -250,7 +250,7 @@ def bbox_iou(bboxes1, bboxes2):
     inter_section = tf.maximum(right_down - left_up, 0.0)
     inter_area = inter_section[..., 0] * inter_section[..., 1]
 
-    union_area = bboxes1_area + bboxes2_area - inter_area
+    union_area = bboxes1_area + bboxes2_area - inter_area + 1e-7
 
     iou = tf.math.divide_no_nan(inter_area, union_area)
 

--- a/official/vision/beta/projects/yolo/ops/box_ops.py
+++ b/official/vision/beta/projects/yolo/ops/box_ops.py
@@ -192,7 +192,7 @@ def compute_giou(box1, box2):
     intersect_mins = tf.math.maximum(box1[..., 0:2], box2[..., 0:2])
     intersect_maxes = tf.math.minimum(box1[..., 2:4], box2[..., 2:4])
     intersect_wh = tf.math.maximum(intersect_maxes - intersect_mins,
-                                   tf.zeros_like(intersect_mins))
+                                   tf.fill(intersect_mins.shape, 1e-7))
     intersection = intersect_wh[..., 0] * intersect_wh[..., 1]
 
     box1_area = tf.math.abs(
@@ -207,7 +207,7 @@ def compute_giou(box1, box2):
     # find the smallest box to encompase both box1 and box2
     c_mins = tf.math.minimum(box1[..., 0:2], box2[..., 0:2])
     c_maxes = tf.math.maximum(box1[..., 2:4], box2[..., 2:4])
-    c = tf.math.abs(tf.reduce_prod(c_mins - c_maxes, axis=-1))
+    c = tf.math.abs(tf.reduce_prod(c_mins - c_maxes, axis=-1)) + 1e-7
 
     # compute giou
     giou = iou - tf.math.divide_no_nan((c - union), c)


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Nan loss during training sometimes.

How was it resolved/added?
1) Found that it was due to calculating of bounding boxes the intersection is sometimes 0.
- Added a small epsilon.
2) Found fishy calculation of iou using different shaped bbox tensors in loss.
- Used alternative calculation.

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #62 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.