### PR TITLE
[Feature] Update multitask serving definition for YOLO.

### DIFF
--- a/official/vision/beta/ops/yolo_ops.py
+++ b/official/vision/beta/ops/yolo_ops.py
@@ -3,11 +3,7 @@ Referenced from https://github.com/hunglc007/tensorflow-yolov4-tflite.
 """
 
 from typing import List, Tuple, Mapping
-import random
 
-import cv2
-import colorsys
-import numpy as np
 import tensorflow as tf
 import tensorflow_addons as tfa
 
@@ -342,58 +338,3 @@ def filter_boxes(box_xywh: tf.Tensor,
     ], axis=-1)
 
     return boxes, pred_conf
-
-
-def read_class_names(class_names_path):
-  """Reads class names from text file.
-  
-  Args:
-    class_names_path: `str`, path to txt file containing classes. Text file
-      should contain one class name per line.
-  """
-  names = {}
-  with open(class_names_path, 'r') as data:
-    for idx, name in enumerate(data):
-      names[idx] = name.strip('\n')
-  return names
-
-
-def draw_bbox(image: np.array, 
-              bboxes: np.array,
-              scores: np.array,
-              classes: np.array,
-              num_bboxes: np.array,
-              class_names: Mapping[int, str], 
-              show_label: bool = True):
-  num_classes = len(class_names)
-  image_h, image_w, _ = image.shape
-  hsv_tuples = [(1.0 * x / num_classes, 1., 1.) for x in range(num_classes)]
-  colors = list(map(lambda x: colorsys.hsv_to_rgb(*x), hsv_tuples))
-  colors = list(map(lambda x: (int(x[0] * 255), int(x[1] * 255), int(x[2] * 255)), colors))
-
-  random.seed(0)
-  random.shuffle(colors)
-  random.seed(None)
-
-  for i in range(num_bboxes[0]):
-    if int(classes[0][i]) < 0 or int(classes[0][i]) > num_classes: continue
-    coor = bboxes[0][i] * [image_h, image_w, image_h, image_w]
-    coor = coor.astype(np.int32)
-
-    fontScale = 0.5
-    score = scores[0][i]
-    class_ind = int(classes[0][i])
-    bbox_color = colors[class_ind]
-    bbox_thick = int(0.6 * (image_h + image_w) / 600)
-    c1, c2 = (coor[1], coor[0]), (coor[3], coor[2])
-    cv2.rectangle(image, c1, c2, bbox_color, bbox_thick)
-
-    if show_label:
-      bbox_mess = '%s: %.2f' % (class_names[class_ind], score)
-      t_size = cv2.getTextSize(bbox_mess, 0, fontScale, thickness=bbox_thick // 2)[0]
-      c3 = (c1[0] + t_size[0], c1[1] - t_size[1] - 3)
-      cv2.rectangle(image, c1, c3, bbox_color, -1) #filled
-
-      cv2.putText(image, bbox_mess, (c1[0], c1[1] - 2), cv2.FONT_HERSHEY_SIMPLEX,
-            fontScale, (0, 0, 0), bbox_thick // 2, lineType=cv2.LINE_AA)
-  return image

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -137,14 +137,14 @@ class MultitaskModule(export_base.ExportModule):
 
     return processed_outputs
   
-  def run(self,
-          image_path_glob: str,
-          output_dir: str,
-          preprocess_fn: Callable[[tf.Tensor], tf.Tensor],
-          inference_fn: Callable[[tf.Tensor], tf.Tensor],
-          class_names_path: str,
-          save_logits_bin: bool = False, 
-          *args, **kwargs):
+  def run_on_image_dir(self,
+                       image_path_glob: str,
+                       output_dir: str,
+                       preprocess_fn: Callable[[tf.Tensor], tf.Tensor],
+                       inference_fn: Callable[[tf.Tensor], tf.Tensor],
+                       class_names_path: str,
+                       save_logits_bin: bool = False, 
+                       *args, **kwargs):
     """Runs inference graph for the model, for given directory of images
     
     Args:

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -178,6 +178,8 @@ class MultitaskModule(export_base.ExportModule):
 
       logits = inference_fn(image)
       cls_env, seg_mask, seg_visualised, yolo_boxes, yolo_classes, yolo_scores = logits
+      if yolo_classes.dtype == 'float32':
+        yolo_classes, yolo_scores = yolo_scores, yolo_classes
 
       if save_logits_bin:
         run_lib.write_tensor_as_bin(tensor=image, 

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -12,10 +12,6 @@ from official.vision.beta.ops.colormaps import get_colormap
 from official.vision.beta.serving import export_base, run_lib
 from official.vision.beta.projects.yolo.ops import box_ops as yolo_box_ops
 
-# RGB mean and stddev from ImageNet
-MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
-STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
-
 
 class MultitaskModule(export_base.ExportModule):
   """Multitask Module."""
@@ -42,8 +38,8 @@ class MultitaskModule(export_base.ExportModule):
 
     # Normalizes image with mean and std pixel values.
     image = preprocess_ops.normalize_image(image,
-                                           offset=MEAN_RGB,
-                                           scale=STDDEV_RGB)
+                                           offset=run_lib.IMAGENET_MEAN_RGB,
+                                           scale=run_lib.IMAGENET_STDDEV_RGB)
 
     image, _ = preprocess_ops.resize_and_crop_image(
         image,

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -163,12 +163,10 @@ class MultitaskModule(export_base.ExportModule):
                                         output_dir=output_dir,
                                         preprocess_fn=preprocess_fn)
 
-    class_names_paths = class_names_path.split(',')
-    if len(class_names_paths) != 2:
-      raise ValueError('Class name paths found: %s' %class_names_paths + \
+    class_names = run_lib.load_class_names(class_names_paths=class_names_path)
+    if len(class_names) != 2:
+      raise ValueError('Class name paths found: %s' %class_names + \
         ' , please specify only 2 (cls, yolo).')
-    class_names = [run_lib.read_class_names(class_names_path=path) 
-      for path in class_names_paths]
     
     for image, img_filename, save_basename in dataset:
 

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -194,18 +194,13 @@ class MultitaskModule(export_base.ExportModule):
       image = tf.image.resize(image, self._input_image_size)
       image = tf.cast(image, tf.uint8)
 
-      def tensor_to_numpy(tensor):
-        if isinstance(tensor, np.ndarray):
-          return tensor
-        return tensor.numpy()      
-
-      output_image = run_lib.draw_bbox(image=tensor_to_numpy(image).squeeze(),
-                                        bboxes=tensor_to_numpy(yolo_boxes),
-                                        scores=tensor_to_numpy(yolo_scores),
-                                        classes=tensor_to_numpy(yolo_classes),
-                                        num_bboxes=tf.constant([yolo_classes.shape[1]]).numpy(),
-                                        class_names=class_names[1])
-      env_val = tensor_to_numpy(cls_env)[0]
+      output_image = run_lib.draw_bbox(image=run_lib.tensor_to_numpy(image).squeeze(),
+                                       bboxes=run_lib.tensor_to_numpy(yolo_boxes),
+                                       scores=run_lib.tensor_to_numpy(yolo_scores),
+                                       classes=run_lib.tensor_to_numpy(yolo_classes),
+                                       num_bboxes=tf.constant([yolo_classes.shape[1]]).numpy(),
+                                       class_names=class_names[1])
+      env_val = run_lib.tensor_to_numpy(cls_env)[0]
       output_image = run_lib.draw_text(image=output_image, 
                                        text_list=[class_names[0][env_val]],
                                        spacing=20)

--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -1,15 +1,16 @@
 # Lint as: python3
 """Semantic segmentation input and model functions for serving/inference."""
 
-from typing import Mapping
+from typing import Mapping, Callable
 
-from absl import logging
+import numpy as np
 import tensorflow as tf
 
 from official.vision.beta.modeling import factory_multitask
-from official.vision.beta.ops import preprocess_ops
+from official.vision.beta.ops import preprocess_ops, yolo_ops, box_ops
 from official.vision.beta.ops.colormaps import get_colormap
-from official.vision.beta.serving import export_base
+from official.vision.beta.serving import export_base, run_lib
+from official.vision.beta.projects.yolo.ops import box_ops as yolo_box_ops
 
 # RGB mean and stddev from ImageNet
 MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
@@ -49,7 +50,8 @@ class MultitaskModule(export_base.ExportModule):
         self._input_image_size,
         padded_size=self._input_image_size,
         aug_scale_min=1.0,
-        aug_scale_max=1.0)
+        aug_scale_max=1.0,
+        preserve_aspect_ratio=False)
     return image
 
   def serve(self, images: tf.Tensor) -> Mapping[str, tf.Tensor]:
@@ -85,17 +87,56 @@ class MultitaskModule(export_base.ExportModule):
     
     for name, output in outputs.items():
       
-      if len(output.shape) == 4:
-        output = tf.image.resize(
-          output, self._input_image_size, method='bilinear')
-      
-      if self._argmax_outputs:
-        output = tf.math.argmax(output, -1)
-      processed_outputs[name] = output
+      if 'classification' in name:
+        if self._argmax_outputs:
+          output = tf.math.argmax(output, -1)
+        else:
+          output = tf.nn.softmax(output)
+        processed_outputs[name] = output
 
-      if self._visualise_outputs and len(output.shape) == 3:
-        colormap = get_colormap(cmap_type='cityscapes_int')
-        processed_outputs[name + '_visualised'] = tf.gather(
-          colormap, tf.cast(tf.squeeze(output), tf.int32))
+      elif 'segmentation' in name:
+        output = tf.image.resize(
+          output, self._input_image_size, method='bilinear')      
+        
+        if self._argmax_outputs:
+          output = tf.math.argmax(output, -1)
+        processed_outputs[name] = output
+        
+        if self._visualise_outputs and len(output.shape) == 3:
+          colormap = get_colormap(cmap_type='cityscapes_int')
+          processed_outputs[name + '_visualised'] = tf.gather(
+            colormap, tf.cast(tf.squeeze(output), tf.int32))
+      
+      elif 'yolo' in name:
+        num_classes = output['predictions']['0'].shape[-1] - 5
+        bbox_tensors, prob_tensors = yolo_ops.concat_tensor_dict(
+          tensor_dict=output['predictions'], 
+          num_classes=num_classes
+        )
+
+        boxes = tf.concat(bbox_tensors, axis=1)
+        boxes = tf.squeeze(yolo_box_ops.xcycwh_to_yxyx(boxes))
+        scores = tf.concat(prob_tensors, axis=1)
+        scores = tf.squeeze(tf.math.reduce_max(scores, axis=-1))
+        classes = tf.argmax(prob_tensors, axis=-1)
+        
+        indices = tf.image.non_max_suppression(boxes=boxes,
+                                               scores=scores,
+                                               max_output_size=20,
+                                               iou_threshold=0.5,
+                                               score_threshold=0.25)
+        
+        boxes = tf.expand_dims(tf.gather(boxes, indices), axis=0)
+        boxes = box_ops.normalize_boxes(boxes, self._input_image_size)
+        scores = tf.expand_dims(tf.gather(scores, indices), axis=0)
+        classes = tf.gather(classes, indices, axis=1)
+
+        processed_outputs[name + 'boxes'] = boxes
+        processed_outputs[name + 'classes'] = classes
+        processed_outputs[name + 'scores'] = scores
+
+      else:
+        raise NotImplementedError('Task type %s is not implemented.' + \
+          'Try renaming the task routine.' %name)
 
     return processed_outputs

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -168,12 +168,12 @@ def read_class_names(class_names_path: str):
   else:
     raise NotImplementedError('File type is not .txt or .json, path %s' %class_names_path)
 
-  if type(list(names.keys())[0]) == int:
+  if type(list(names.keys())[0]) != int:
     raise ValueError('Loaded dict %s has wrong key type %s' %(
-      class_names_path, type(list(names.keys()[0])))) 
-  if type(list(names.values())[0]) == str:
+      class_names_path, type(list(names.keys())[0]))) 
+  if type(list(names.values())[0]) != str:
     raise ValueError('Loaded dict %s has wrong value type %s' %(
-      class_names_path, type(list(names.values()[0]))))
+      class_names_path, type(list(names.values())[0])))
 
   return names
 

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -168,10 +168,12 @@ def read_class_names(class_names_path):
   else:
     raise NotImplementedError('File type is not .txt or .json, path %s' %class_names_path)
 
-  assert type(list(names.keys())[0]) == int, 'Loaded dict %s has wrong key type %s' %(
-    class_names_path, type(list(names.keys()[0])))
-  assert type(list(names.values())[0]) == str, 'Loaded dict %s has wrong value type %s' %(
-    class_names_path, type(list(names.values()[0])))
+  if type(list(names.keys())[0]) == int:
+    raise ValueError('Loaded dict %s has wrong key type %s' %(
+      class_names_path, type(list(names.keys()[0])))) 
+  if type(list(names.values())[0]) == str:
+    raise ValueError('Loaded dict %s has wrong value type %s' %(
+      class_names_path, type(list(names.values()[0]))))
 
   return names
 

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -190,14 +190,29 @@ def draw_bbox(image: np.array,
               classes: np.array,
               num_bboxes: np.array,
               class_names: Mapping[int, str], 
-              show_label: bool = True):
+              show_label: bool = True,
+              seed: int = 0):
+  """ Draw bounding boxes on given image, and corresponding class and scores.
+  Color palette can be fixed using a seed.
+
+  Args:
+    image: `np.array`, of shape (height, width, 3), denoting RGB image
+    bboxes: `np.array`, of shape (num_boxes, 4), denoting (ymin, xmin, ymax, xmax)
+      coordinates of each bounding box instance
+    scores: `np.array`, of shape (num_boxes), denoting confidence scores (0-1)
+    classes: `np.array`, of shape (num_boxes), denoting class of corresponding bbox
+    num_bboxes: `np.array`, of shape (1), denoting number of bboxes
+    class_names: `dict[int, str]`, mapping each class index to describing string
+    show_label: `bool`, flag to show class and scores
+    seed: `int`, number to set color palette
+  """
   num_classes = len(class_names)
   image_h, image_w, _ = image.shape
   hsv_tuples = [(1.0 * x / num_classes, 1., 1.) for x in range(num_classes)]
   colors = list(map(lambda x: colorsys.hsv_to_rgb(*x), hsv_tuples))
   colors = list(map(lambda x: (int(x[0] * 255), int(x[1] * 255), int(x[2] * 255)), colors))
 
-  random.seed(0)
+  random.seed(seed)
   random.shuffle(colors)
   random.seed(None)
 

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -1,13 +1,17 @@
 r"""Vision models run inference utility function."""
 
-from typing import Callable, Optional
+from typing import Callable, Optional, List, Mapping
 import os
 import glob
+import json
+import random
+import colorsys
 
 from absl import flags
+import cv2
+import numpy as np
 import tensorflow as tf
 
-# from official.common import registry_imports  # pylint: disable=unused-import
 from official.core import exp_factory
 from official.modeling import hyperparams
 from official.vision.beta import configs
@@ -32,7 +36,8 @@ def define_flags():
   # optional flags, supplied as kwargs
   flags.DEFINE_boolean('visualise', None, '(Segmentation) Flag to visualise mask.')
   flags.DEFINE_boolean('stitch_original', None, '(Segmentation) Flag to stitch image at the side.')
-  flags.DEFINE_string('class_names_path', None, '(Yolo) Txt file with class names.')
+  flags.DEFINE_string('class_names_path', None, '(Yolo/Cls) Csv of paths to txt' + \
+    ' files with class names.')
 
 
 def inference_dataset(image_path_glob: str,
@@ -133,3 +138,97 @@ def get_export_module(experiment: str,
         type(params.task)))
 
   return export_module
+
+
+def read_class_names(class_names_path):
+  """Reads class names from text file.
+  Supports .txt and .json.
+  
+  Args:
+    class_names_path: `str`, path to json/txt file containing classes. 
+      Text file should contain one class name per line.
+      Json file should contain only one dictionary, `Mapping[int, str]`
+  """
+  
+  names = {}
+  if class_names_path.endswith('.txt'):
+    with open(class_names_path, 'r') as data:
+      for idx, name in enumerate(data):
+        names[idx] = name.strip('\n')
+  
+  elif class_names_path.endswith('.json'):
+    with open(class_names_path) as f:
+      names = json.load(f)
+    if type(list(names.keys())[0]) == str and type(list(names.values())[0]) == int:
+      names = dict((v,k) for k,v in names.items())
+
+  else:
+    raise NotImplementedError('File type is not .txt or .json, path %s' %class_names_path)
+
+  assert type(list(names.keys())[0]) == int, 'Loaded dict %s has wrong key type %s' %(
+    class_names_path, type(list(names.keys()[0])))
+  assert type(list(names.values())[0]) == str, 'Loaded dict %s has wrong value type %s' %(
+    class_names_path, type(list(names.values()[0])))
+
+  return names
+
+
+def draw_bbox(image: np.array, 
+              bboxes: np.array,
+              scores: np.array,
+              classes: np.array,
+              num_bboxes: np.array,
+              class_names: Mapping[int, str], 
+              show_label: bool = True):
+  num_classes = len(class_names)
+  image_h, image_w, _ = image.shape
+  hsv_tuples = [(1.0 * x / num_classes, 1., 1.) for x in range(num_classes)]
+  colors = list(map(lambda x: colorsys.hsv_to_rgb(*x), hsv_tuples))
+  colors = list(map(lambda x: (int(x[0] * 255), int(x[1] * 255), int(x[2] * 255)), colors))
+
+  random.seed(0)
+  random.shuffle(colors)
+  random.seed(None)
+
+  for i in range(num_bboxes[0]):
+    if int(classes[0][i]) < 0 or int(classes[0][i]) > num_classes: continue
+    coor = bboxes[0][i] * [image_h, image_w, image_h, image_w]
+    coor = coor.astype(np.int32)
+
+    fontScale = 0.5
+    score = scores[0][i]
+    class_ind = int(classes[0][i])
+    bbox_color = colors[class_ind]
+    bbox_thick = int(0.6 * (image_h + image_w) / 600)
+    c1, c2 = (coor[1], coor[0]), (coor[3], coor[2])
+    cv2.rectangle(image, c1, c2, bbox_color, bbox_thick)
+
+    if show_label:
+      bbox_mess = '%s: %.2f' % (class_names[class_ind], score)
+      t_size = cv2.getTextSize(bbox_mess, 0, fontScale, thickness=bbox_thick // 2)[0]
+      c3 = (c1[0] + t_size[0], c1[1] - t_size[1] - 3)
+      cv2.rectangle(image, c1, c3, bbox_color, -1) #filled
+
+      cv2.putText(image, bbox_mess, (c1[0], c1[1] - 2), cv2.FONT_HERSHEY_SIMPLEX,
+            fontScale, (0, 0, 0), bbox_thick // 2, lineType=cv2.LINE_AA)
+  return image
+
+
+def draw_text(image: np.array, 
+              text_list: List[str],
+              spacing: int = 50):
+    """ Writes list of messages on image, separated by newline 
+    
+    Args:
+      image: `np.array`, of shape (height, width, 3), RGB image
+      text_list: `List[str]`, list of texts to write on each line
+      spacing: `int`, spacing in pixels
+    """
+
+    pos = spacing
+    for text in text_list:
+        image = cv2.putText(image, text,
+                            (spacing, pos), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 0, 0), 2)
+        pos += spacing
+
+    return image

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -143,7 +143,7 @@ def get_export_module(experiment: str,
   return export_module
 
 
-def read_class_names(class_names_path):
+def read_class_names(class_names_path: str):
   """Reads class names from text file.
   Supports .txt and .json.
   
@@ -176,6 +176,23 @@ def read_class_names(class_names_path):
       class_names_path, type(list(names.values()[0]))))
 
   return names
+
+
+def load_class_names(class_names_paths: str):
+  """Reads all class name .txts and .jsons, in paths separated by commas.
+
+  Args:
+    class_names_paths: Paths separated by commas, to .txt/json class name files.
+      Text file should contain one class name per line.
+      Json file should contain only one dictionary, `Mapping[int, str]`
+  
+  Returns:
+    `List[Mapping[int, str]]`, denoting class index to class name mapping for each
+      class name path specified, separated by commas.
+  """
+  class_names_paths = class_names_paths.split(',')
+  return [read_class_names(class_names_path=path) 
+    for path in class_names_paths]
 
 
 def tensor_to_numpy(tensor):

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -22,6 +22,9 @@ from official.vision.beta.serving import semantic_segmentation
 from official.vision.beta.serving import yolo
 from official.vision.beta.serving import multitask
 
+IMAGENET_MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
+IMAGENET_STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
+
 
 def define_flags():
   """Defines flags specific for running inferences."""

--- a/official/vision/beta/serving/run_lib.py
+++ b/official/vision/beta/serving/run_lib.py
@@ -176,6 +176,12 @@ def read_class_names(class_names_path):
   return names
 
 
+def tensor_to_numpy(tensor):
+  if isinstance(tensor, np.ndarray):
+    return tensor
+  return tensor.numpy()  
+
+
 def draw_bbox(image: np.array, 
               bboxes: np.array,
               scores: np.array,

--- a/official/vision/beta/serving/run_model.py
+++ b/official/vision/beta/serving/run_model.py
@@ -28,14 +28,14 @@ def main(_):
     outputs = export_module.serve(images)
     return [v for k, v in outputs.items()]
   
-  export_module.run(image_path_glob=FLAGS.image_path_glob, 
-                    output_dir=FLAGS.output_dir,
-                    preprocess_fn=None,
-                    inference_fn=inference_fn, 
-                    visualise=FLAGS.visualise, 
-                    stitch_original=FLAGS.stitch_original,
-                    class_names_path=FLAGS.class_names_path,
-                    save_logits_bin=FLAGS.save_logits_bin)
+  export_module.run_on_image_dir(image_path_glob=FLAGS.image_path_glob, 
+                                 output_dir=FLAGS.output_dir,
+                                 preprocess_fn=None,
+                                 inference_fn=inference_fn, 
+                                 visualise=FLAGS.visualise, 
+                                 stitch_original=FLAGS.stitch_original,
+                                 class_names_path=FLAGS.class_names_path,
+                                 save_logits_bin=FLAGS.save_logits_bin)
 
 
 if __name__ == '__main__':

--- a/official/vision/beta/serving/run_saved_model.py
+++ b/official/vision/beta/serving/run_saved_model.py
@@ -28,14 +28,14 @@ def main(_):
   def inference_fn(image):
     return [v for k, v in sorted(model_fn(image).items())]
   
-  export_module.run(image_path_glob=FLAGS.image_path_glob, 
-                    output_dir=FLAGS.output_dir,
-                    preprocess_fn=preprocess_fn,
-                    inference_fn=inference_fn, 
-                    visualise=FLAGS.visualise, 
-                    stitch_original=FLAGS.stitch_original,
-                    class_names_path=FLAGS.class_names_path,
-                    save_logits_bin=FLAGS.save_logits_bin)
+  export_module.run_on_image_dir(image_path_glob=FLAGS.image_path_glob, 
+                                 output_dir=FLAGS.output_dir,
+                                 preprocess_fn=None,
+                                 inference_fn=inference_fn, 
+                                 visualise=FLAGS.visualise, 
+                                 stitch_original=FLAGS.stitch_original,
+                                 class_names_path=FLAGS.class_names_path,
+                                 save_logits_bin=FLAGS.save_logits_bin)
 
 
 if __name__ == '__main__':

--- a/official/vision/beta/serving/run_tflite_model.py
+++ b/official/vision/beta/serving/run_tflite_model.py
@@ -36,14 +36,14 @@ def main(_):
     image = tf.cast(image, dtype=tf.uint8)
     return image
 
-  export_module.run(image_path_glob=FLAGS.image_path_glob, 
-                    output_dir=FLAGS.output_dir,
-                    preprocess_fn=preprocess_fn,
-                    inference_fn=inference_fn, 
-                    visualise=FLAGS.visualise, 
-                    stitch_original=FLAGS.stitch_original,
-                    class_names_path=FLAGS.class_names_path,
-                    save_logits_bin=FLAGS.save_logits_bin)
+  export_module.run_on_image_dir(image_path_glob=FLAGS.image_path_glob, 
+                                 output_dir=FLAGS.output_dir,
+                                 preprocess_fn=None,
+                                 inference_fn=inference_fn, 
+                                 visualise=FLAGS.visualise, 
+                                 stitch_original=FLAGS.stitch_original,
+                                 class_names_path=FLAGS.class_names_path,
+                                 save_logits_bin=FLAGS.save_logits_bin)
 
 
 if __name__ == '__main__':

--- a/official/vision/beta/serving/semantic_segmentation.py
+++ b/official/vision/beta/serving/semantic_segmentation.py
@@ -109,15 +109,15 @@ class SegmentationModule(export_base.ExportModule):
 
     return processed_outputs
 
-  def run(self,
-          image_path_glob: str,
-          output_dir: str,
-          preprocess_fn: Callable[[tf.Tensor], tf.Tensor],
-          inference_fn: Callable[[tf.Tensor], tf.Tensor],
-          visualise: bool = True,
-          stitch_original: bool = True,
-          save_logits_bin: bool = False,
-          *args, **kwargs):
+  def run_on_image_dir(self,
+                       image_path_glob: str,
+                       output_dir: str,
+                       preprocess_fn: Callable[[tf.Tensor], tf.Tensor],
+                       inference_fn: Callable[[tf.Tensor], tf.Tensor],
+                       visualise: bool = True,
+                       stitch_original: bool = True,
+                       save_logits_bin: bool = False,
+                       *args, **kwargs):
     """Runs inference graph for the model, for given directory of images
     
     Args:

--- a/official/vision/beta/serving/semantic_segmentation.py
+++ b/official/vision/beta/serving/semantic_segmentation.py
@@ -63,7 +63,8 @@ class SegmentationModule(export_base.ExportModule):
         self._input_image_size,
         padded_size=self._input_image_size,
         aug_scale_min=1.0,
-        aug_scale_max=1.0)
+        aug_scale_max=1.0,
+        preserve_aspect_ratio=False)
     return image
 
   def serve(self, images):

--- a/official/vision/beta/serving/semantic_segmentation.py
+++ b/official/vision/beta/serving/semantic_segmentation.py
@@ -26,10 +26,6 @@ from official.vision.beta.ops.colormaps import get_colormap
 from official.vision.beta.serving import export_base, run_lib
 
 
-MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
-STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
-
-
 class SegmentationModule(export_base.ExportModule):
   """Segmentation Module."""
 
@@ -55,8 +51,8 @@ class SegmentationModule(export_base.ExportModule):
 
     # Normalizes image with mean and std pixel values.
     image = preprocess_ops.normalize_image(image,
-                                           offset=MEAN_RGB,
-                                           scale=STDDEV_RGB)
+                                           offset=run_lib.IMAGENET_MEAN_RGB,
+                                           scale=run_lib.IMAGENET_STDDEV_RGB)
 
     image, _ = preprocess_ops.resize_and_crop_image(
         image,

--- a/official/vision/beta/serving/yolo.py
+++ b/official/vision/beta/serving/yolo.py
@@ -11,10 +11,6 @@ from official.vision.beta.serving import export_base, run_lib
 from official.vision.beta.projects.yolo.ops import box_ops as yolo_box_ops
 
 
-MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
-STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
-
-
 class YoloModule(export_base.ExportModule):
   """YOLO Module."""
 
@@ -32,8 +28,8 @@ class YoloModule(export_base.ExportModule):
 
     # Normalizes image with mean and std pixel values.
     image = preprocess_ops.normalize_image(image,
-                                           offset=MEAN_RGB,
-                                           scale=STDDEV_RGB)
+                                           offset=run_lib.IMAGENET_MEAN_RGB,
+                                           scale=run_lib.IMAGENET_STDDEV_RGB)
 
     image, _ = preprocess_ops.resize_and_crop_image(
         image,

--- a/official/vision/beta/serving/yolo.py
+++ b/official/vision/beta/serving/yolo.py
@@ -142,15 +142,10 @@ class YoloModule(export_base.ExportModule):
       image = tf.image.resize(image, self._input_image_size)
       image = tf.cast(image, tf.uint8)
 
-      def tensor_to_numpy(tensor):
-        if isinstance(tensor, np.ndarray):
-          return tensor
-        return tensor.numpy()
-
-      output_image = run_lib.draw_bbox(image=tensor_to_numpy(image).squeeze(),
-                                       bboxes=tensor_to_numpy(boxes),
-                                       scores=tensor_to_numpy(scores),
-                                       classes=tensor_to_numpy(classes),
+      output_image = run_lib.draw_bbox(image=run_lib.tensor_to_numpy(image).squeeze(),
+                                       bboxes=run_lib.tensor_to_numpy(boxes),
+                                       scores=run_lib.tensor_to_numpy(scores),
+                                       classes=run_lib.tensor_to_numpy(classes),
                                        num_bboxes=tf.constant([classes.shape[1]]).numpy(),
                                        class_names=class_names)
       

--- a/official/vision/beta/serving/yolo.py
+++ b/official/vision/beta/serving/yolo.py
@@ -93,14 +93,14 @@ class YoloModule(export_base.ExportModule):
       'scores': scores
     }
 
-  def run(self,
-          image_path_glob: str,
-          output_dir: str,
-          preprocess_fn: Callable[[tf.Tensor], tf.Tensor],
-          inference_fn: Callable[[tf.Tensor], tf.Tensor],
-          class_names_path: str,
-          save_logits_bin: bool = False, 
-          *args, **kwargs):
+  def run_on_image_dir(self,
+                       image_path_glob: str,
+                       output_dir: str,
+                       preprocess_fn: Callable[[tf.Tensor], tf.Tensor],
+                       inference_fn: Callable[[tf.Tensor], tf.Tensor],
+                       class_names_path: str,
+                       save_logits_bin: bool = False, 
+                       *args, **kwargs):
     """Runs inference graph for the model, for given directory of images
     
     Args:

--- a/official/vision/beta/serving/yolo.py
+++ b/official/vision/beta/serving/yolo.py
@@ -122,6 +122,7 @@ class YoloModule(export_base.ExportModule):
     dataset = run_lib.inference_dataset(image_path_glob=image_path_glob,
                                         output_dir=output_dir,
                                         preprocess_fn=preprocess_fn)
+    class_names = run_lib.read_class_names(class_names_path=class_names_path)
     
     for image, img_filename, save_basename in dataset:
 
@@ -138,23 +139,24 @@ class YoloModule(export_base.ExportModule):
         run_lib.write_tensor_as_bin(tensor=boxes, 
                                     output_path=save_basename + '_boxes')
         run_lib.write_tensor_as_bin(tensor=scores, 
-                                    output_path=save_basename + 'scores')
+                                    output_path=save_basename + '_scores')
+        run_lib.write_tensor_as_bin(tensor=classes,
+                                    output_path=save_basename + '_classes')
 
       image = tf.image.resize(image, self._input_image_size)
       image = tf.cast(image, tf.uint8)
-      class_names = yolo_ops.read_class_names(class_names_path=class_names_path)
 
       def tensor_to_numpy(tensor):
         if isinstance(tensor, np.ndarray):
           return tensor
         return tensor.numpy()
 
-      output_image = yolo_ops.draw_bbox(image=tensor_to_numpy(image).squeeze(),
-                                        bboxes=tensor_to_numpy(boxes),
-                                        scores=tensor_to_numpy(scores),
-                                        classes=tensor_to_numpy(classes),
-                                        num_bboxes=tf.constant([classes.shape[1]]).numpy(),
-                                        class_names=class_names)
+      output_image = run_lib.draw_bbox(image=tensor_to_numpy(image).squeeze(),
+                                       bboxes=tensor_to_numpy(boxes),
+                                       scores=tensor_to_numpy(scores),
+                                       classes=tensor_to_numpy(classes),
+                                       num_bboxes=tf.constant([classes.shape[1]]).numpy(),
+                                       class_names=class_names)
       
       output_image = tf.image.encode_png(output_image)
       tf.io.write_file(save_basename + '.png', output_image)


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Multihead export module does not support YOLO head.

How was it resolved/added?
Add YOLO support in serving definition to export and run inference for multihead.
Refactor inference functions from yolo_ops into run_lib.

![image](https://user-images.githubusercontent.com/57937231/125604192-b4258204-fa55-4cd1-9033-9b43624ce5db.png)

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #70.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.