### PR TITLE
increase max BBoX to 50

### DIFF
--- a/official/vision/beta/dataloaders/yolo_input.py
+++ b/official/vision/beta/dataloaders/yolo_input.py
@@ -11,6 +11,7 @@ from official.vision.beta.projects.yolo.ops import box_ops as yolo_box_ops
 
 MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)
 STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)
+MAX_DISPLAY_BBOX = 50
 
 
 class Decoder(decoder.Decoder):
@@ -220,13 +221,15 @@ class Parser(parser.Parser):
       strides=self.strides,
       anchors=self.anchors)
     
-    # pad / limit to 10 boxes for constant size
+    # TODO: Figure out why we need to fix the num BBOX if not there will be an error
+    # https://github.com/whizzmobility/models/pull/61
+    # pad / limit to MAX_DISPLAY_BBOX boxes for constant size
     raw_bboxes = boxes
     num_bboxes = tf.shape(raw_bboxes)[0]
-    if num_bboxes > 10:
-      raw_bboxes = raw_bboxes[:, :10]
+    if num_bboxes > MAX_DISPLAY_BBOX:
+      raw_bboxes = raw_bboxes[:, :MAX_DISPLAY_BBOX]
     else:
-      paddings = tf.stack([0, 10-num_bboxes], axis=-1)
+      paddings = tf.stack([0, MAX_DISPLAY_BBOX-num_bboxes], axis=-1)
       paddings = tf.stack([paddings, [0,0]], axis=0)
       raw_bboxes = tf.pad(raw_bboxes, paddings)
 


### PR DESCRIPTION
## Description
What feature/issue was addressed?
#88

How was it resolved/added?
Resolved the issue by increasing the number of output tensors for visualisation to 50. This is not a good fix in the LR as we have not found out the root cause of why the number of output tensors cant be dynamic

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #_[issue number]_
#88 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.

## Checklist
- [ ] I have performed a self-review of my own code. Feel free to destroy my PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.