### PR TITLE
[Bug] Tune non-max suppression

### DIFF
--- a/official/vision/beta/serving/multitask.py
+++ b/official/vision/beta/serving/multitask.py
@@ -129,7 +129,7 @@ class MultitaskModule(export_base.ExportModule):
         indices = tf.image.non_max_suppression(boxes=boxes,
                                                scores=scores,
                                                max_output_size=20,
-                                               iou_threshold=0.5,
+                                               iou_threshold=0.25,
                                                score_threshold=0.25)
         
         boxes = tf.gather(boxes, indices)


### PR DESCRIPTION
## Description
What feature/issue was addressed?
Nms iou threshold was too high, too many boxes are selected.
Tuned the value according to typical box labels generation for anchor-based models (0.25-0.3).

(IoU threshold 0.25)
![image](https://user-images.githubusercontent.com/57937231/129663119-ed600de9-f31d-472f-90c8-061c74cc7a96.png)

(IoU threshold 0.5)
![image](https://user-images.githubusercontent.com/57937231/129663137-ddf1dc24-c42b-466d-a3c6-0f56aebee95c.png)

How was it resolved/added?

Any dependencies required for the change?

## Issue reference

Please reference the issue this PR will close: #90.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (Specify)

## Tests

Any reproducable method of testing to verify changes? \
List relevant details for the test configuration.

## Checklist
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.